### PR TITLE
Fix asset paths for GitHub Pages deployment

### DIFF
--- a/clients/index.html
+++ b/clients/index.html
@@ -6,7 +6,7 @@
   <title>Our Clients | Moocow Media</title>
   <meta name="description" content="Partnerships with inspiring organisations across Brighton and beyond." />
   <link rel="canonical" href="https://moocowmedia.co.uk/clients/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="../assets/style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"WebPage","name":"Our Clients","url":"https://moocowmedia.co.uk/clients/"}
   </script>
@@ -14,14 +14,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="../">Home</a>
+      <a href="../strategy/">Strategy</a>
+      <a href="../seo-services-brighton/">SEO Services</a>
+      <a href="../clients/">Clients</a>
+      <a href="../our-work/">Our Work</a>
+      <a href="../our-approach-to-web-design/">Approach</a>
+      <a href="../insights/">Insights</a>
+      <a href="../web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Moocow Media – Forward-Thinking Web Agency in Brighton</title>
   <meta name="description" content="Brighton-based web agency creating future-proof websites, SEO strategies and digital experiences." />
   <link rel="canonical" href="https://moocowmedia.co.uk/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="assets/style.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -24,14 +24,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="./">Home</a>
+      <a href="strategy/">Strategy</a>
+      <a href="seo-services-brighton/">SEO Services</a>
+      <a href="clients/">Clients</a>
+      <a href="our-work/">Our Work</a>
+      <a href="our-approach-to-web-design/">Approach</a>
+      <a href="insights/">Insights</a>
+      <a href="web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">

--- a/insights/index.html
+++ b/insights/index.html
@@ -6,7 +6,7 @@
   <title>Insights | Moocow Media</title>
   <meta name="description" content="Thoughts on design, technology and sustainable digital practice." />
   <link rel="canonical" href="https://moocowmedia.co.uk/insights/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="../assets/style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"WebPage","name":"Insights","url":"https://moocowmedia.co.uk/insights/"}
   </script>
@@ -14,14 +14,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="../">Home</a>
+      <a href="../strategy/">Strategy</a>
+      <a href="../seo-services-brighton/">SEO Services</a>
+      <a href="../clients/">Clients</a>
+      <a href="../our-work/">Our Work</a>
+      <a href="../our-approach-to-web-design/">Approach</a>
+      <a href="../insights/">Insights</a>
+      <a href="../web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">

--- a/our-approach-to-web-design/index.html
+++ b/our-approach-to-web-design/index.html
@@ -6,7 +6,7 @@
   <title>Our Approach to Web Design | Moocow Media</title>
   <meta name="description" content="A collaborative process that balances creativity with performance." />
   <link rel="canonical" href="https://moocowmedia.co.uk/our-approach-to-web-design/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="../assets/style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"WebPage","name":"Our Approach to Web Design","url":"https://moocowmedia.co.uk/our-approach-to-web-design/"}
   </script>
@@ -14,14 +14,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="../">Home</a>
+      <a href="../strategy/">Strategy</a>
+      <a href="../seo-services-brighton/">SEO Services</a>
+      <a href="../clients/">Clients</a>
+      <a href="../our-work/">Our Work</a>
+      <a href="../our-approach-to-web-design/">Approach</a>
+      <a href="../insights/">Insights</a>
+      <a href="../web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">

--- a/our-work/index.html
+++ b/our-work/index.html
@@ -6,7 +6,7 @@
   <title>Our Work | Moocow Media</title>
   <meta name="description" content="A showcase of digital projects delivered by our Brighton team." />
   <link rel="canonical" href="https://moocowmedia.co.uk/our-work/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="../assets/style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"WebPage","name":"Our Work","url":"https://moocowmedia.co.uk/our-work/"}
   </script>
@@ -14,14 +14,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="../">Home</a>
+      <a href="../strategy/">Strategy</a>
+      <a href="../seo-services-brighton/">SEO Services</a>
+      <a href="../clients/">Clients</a>
+      <a href="../our-work/">Our Work</a>
+      <a href="../our-approach-to-web-design/">Approach</a>
+      <a href="../insights/">Insights</a>
+      <a href="../web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">

--- a/seo-services-brighton/index.html
+++ b/seo-services-brighton/index.html
@@ -6,7 +6,7 @@
   <title>SEO Services in Brighton | Moocow Media</title>
   <meta name="description" content="Search engine optimisation tailored for Brighton businesses." />
   <link rel="canonical" href="https://moocowmedia.co.uk/seo-services-brighton/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="../assets/style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"WebPage","name":"SEO Services in Brighton","url":"https://moocowmedia.co.uk/seo-services-brighton/"}
   </script>
@@ -14,14 +14,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="../">Home</a>
+      <a href="../strategy/">Strategy</a>
+      <a href="../seo-services-brighton/">SEO Services</a>
+      <a href="../clients/">Clients</a>
+      <a href="../our-work/">Our Work</a>
+      <a href="../our-approach-to-web-design/">Approach</a>
+      <a href="../insights/">Insights</a>
+      <a href="../web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">

--- a/strategy/index.html
+++ b/strategy/index.html
@@ -6,7 +6,7 @@
   <title>Digital Strategy | Moocow Media</title>
   <meta name="description" content="Strategic planning for impactful digital experiences." />
   <link rel="canonical" href="https://moocowmedia.co.uk/strategy/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="../assets/style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"WebPage","name":"Digital Strategy","url":"https://moocowmedia.co.uk/strategy/"}
   </script>
@@ -14,14 +14,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="../">Home</a>
+      <a href="../strategy/">Strategy</a>
+      <a href="../seo-services-brighton/">SEO Services</a>
+      <a href="../clients/">Clients</a>
+      <a href="../our-work/">Our Work</a>
+      <a href="../our-approach-to-web-design/">Approach</a>
+      <a href="../insights/">Insights</a>
+      <a href="../web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">

--- a/terms-conditions/index.html
+++ b/terms-conditions/index.html
@@ -6,7 +6,7 @@
   <title>Terms &amp; Conditions | Moocow Media</title>
   <meta name="description" content="Terms and conditions for using Moocow Media's website and services." />
   <link rel="canonical" href="https://moocowmedia.co.uk/terms-conditions/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="../assets/style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"WebPage","name":"Terms and Conditions","url":"https://moocowmedia.co.uk/terms-conditions/"}
   </script>
@@ -14,14 +14,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="../">Home</a>
+      <a href="../strategy/">Strategy</a>
+      <a href="../seo-services-brighton/">SEO Services</a>
+      <a href="../clients/">Clients</a>
+      <a href="../our-work/">Our Work</a>
+      <a href="../our-approach-to-web-design/">Approach</a>
+      <a href="../insights/">Insights</a>
+      <a href="../web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">

--- a/web-design-in-brighton-2/index.html
+++ b/web-design-in-brighton-2/index.html
@@ -6,7 +6,7 @@
   <title>Web Design in Brighton – Version 2 | Moocow Media</title>
   <meta name="description" content="Alternative take on our Brighton web design services." />
   <link rel="canonical" href="https://moocowmedia.co.uk/web-design-in-brighton-2/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="../assets/style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"WebPage","name":"Web Design in Brighton","url":"https://moocowmedia.co.uk/web-design-in-brighton-2/"}
   </script>
@@ -14,14 +14,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="../">Home</a>
+      <a href="../strategy/">Strategy</a>
+      <a href="../seo-services-brighton/">SEO Services</a>
+      <a href="../clients/">Clients</a>
+      <a href="../our-work/">Our Work</a>
+      <a href="../our-approach-to-web-design/">Approach</a>
+      <a href="../insights/">Insights</a>
+      <a href="../web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">

--- a/web-design-in-brighton/index.html
+++ b/web-design-in-brighton/index.html
@@ -6,7 +6,7 @@
   <title>Web Design in Brighton | Moocow Media</title>
   <meta name="description" content="Creative web design services for Brighton organisations." />
   <link rel="canonical" href="https://moocowmedia.co.uk/web-design-in-brighton/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="../assets/style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"WebPage","name":"Web Design in Brighton","url":"https://moocowmedia.co.uk/web-design-in-brighton/"}
   </script>
@@ -14,14 +14,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="../">Home</a>
+      <a href="../strategy/">Strategy</a>
+      <a href="../seo-services-brighton/">SEO Services</a>
+      <a href="../clients/">Clients</a>
+      <a href="../our-work/">Our Work</a>
+      <a href="../our-approach-to-web-design/">Approach</a>
+      <a href="../insights/">Insights</a>
+      <a href="../web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">

--- a/web-designers-in-brighton/index.html
+++ b/web-designers-in-brighton/index.html
@@ -6,7 +6,7 @@
   <title>Web Designers in Brighton | Moocow Media</title>
   <meta name="description" content="Meet the Brighton-based designers crafting accessible, future-ready websites." />
   <link rel="canonical" href="https://moocowmedia.co.uk/web-designers-in-brighton/" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="../assets/style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"WebPage","name":"Web Designers in Brighton","url":"https://moocowmedia.co.uk/web-designers-in-brighton/"}
   </script>
@@ -14,14 +14,14 @@
 <body>
   <header>
     <nav class="container">
-      <a href="/">Home</a>
-      <a href="/strategy/">Strategy</a>
-      <a href="/seo-services-brighton/">SEO Services</a>
-      <a href="/clients/">Clients</a>
-      <a href="/our-work/">Our Work</a>
-      <a href="/our-approach-to-web-design/">Approach</a>
-      <a href="/insights/">Insights</a>
-      <a href="/web-designers-in-brighton/">Designers</a>
+      <a href="../">Home</a>
+      <a href="../strategy/">Strategy</a>
+      <a href="../seo-services-brighton/">SEO Services</a>
+      <a href="../clients/">Clients</a>
+      <a href="../our-work/">Our Work</a>
+      <a href="../our-approach-to-web-design/">Approach</a>
+      <a href="../insights/">Insights</a>
+      <a href="../web-designers-in-brighton/">Designers</a>
     </nav>
   </header>
   <main class="container">


### PR DESCRIPTION
## Summary
- use relative paths for stylesheet and navigation links so assets load on GitHub Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689604097868832382e189ee14878ceb